### PR TITLE
Bump target SDK version

### DIFF
--- a/AndroidManifest.xml
+++ b/AndroidManifest.xml
@@ -11,6 +11,7 @@
             android:name=".MainActivity"
             android:configChanges="orientation|keyboardHidden|screenSize"
             android:label="@string/app_name"
+            android:exported="true"
             android:screenOrientation="portrait">
             <intent-filter>
                 <action android:name="android.intent.action.MAIN" />

--- a/build.gradle
+++ b/build.gradle
@@ -6,7 +6,7 @@ buildscript {
     }
 
     dependencies {
-        classpath 'com.android.tools.build:gradle:3.2.1'
+        classpath 'com.android.tools.build:gradle:7.2.2'
     }
 }
 
@@ -21,15 +21,15 @@ allprojects {
 apply plugin: 'com.android.application'
 
 android {
-    compileSdkVersion 28
-    buildToolsVersion '28.0.3'
+    compileSdkVersion 34
+    buildToolsVersion '30.0.3'
 
     defaultConfig {
         applicationId "com.uberspot.a2048"
-        minSdkVersion 14
-        targetSdkVersion 28
-        versionCode 25
-        versionName "2.2"
+        minSdkVersion 28
+        targetSdkVersion 35
+        versionCode 26
+        versionName "2.3"
     }
 
     sourceSets {

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,6 @@
+#Sun Aug 11 11:33:55 AEST 2024
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-4.10.3-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-7.3.3-bin.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists

--- a/res/raw/changelog_master.xml
+++ b/res/raw/changelog_master.xml
@@ -2,6 +2,12 @@
 <changelog xmlns:tools="http://schemas.android.com/tools"
     tools:ignore="MissingDefaultResource">
     <release
+        version="2.3"
+        versioncode="26">
+        <change> (2.3) Bumped minSdkVersion from 14 to 28 </change>
+        <change> (2.3) Bumped targetSdkVersion from 28 to 34 </change>
+    </release>
+    <release
         version="2.2"
         versioncode="25">
         <change>(2.2) Bumped minSdkVersion from 8 (Froyo) to 14 (ICS)</change>


### PR DESCRIPTION
Google requires APKs be built for a recent version or it will declare the app is unsafe and make it harder to install.

The one mandatory change in the intervening time appears to be the "exported" property. With these changes I'm running the debug build on a Pixel 8 (Android 14).